### PR TITLE
Update SerialWombat_mp_i2c.py to use super().__init__()

### DIFF
--- a/interfaces/micropython/SerialWombat_mp_i2c.py
+++ b/interfaces/micropython/SerialWombat_mp_i2c.py
@@ -9,7 +9,7 @@ class SerialWombatChip_mp_i2c(SerialWombat.SerialWombatChip):
     def __init__(self,i2c_port,address):
         self.i2c = i2c_port
         self.address = address
-        SerialWombat.SerialWombatChip.__init__(self)
+        super().__init__()
 
 
     def sendReceivePacketHardware (self,tx):


### PR DESCRIPTION
If I'm understanding the intent of this line, I think this is the preferred method to initialize.
using super() to init the micropython I2C chip